### PR TITLE
welcome 페이지 구현

### DIFF
--- a/src/pages/auth/WelcomePage.tsx
+++ b/src/pages/auth/WelcomePage.tsx
@@ -1,8 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 import LogoIcon from "@/assets/logo.png";
 
 export default function WelcomePage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 3초 후 메인 화면(/main)으로 이동
+    const timer = setTimeout(() => {
+      navigate("/HomePage");
+    }, 3000);
+
+    // 컴포넌트가 언마운트되면 타이머를 클리어
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
   return (
     <Container>
       <LogoWrapper>

--- a/src/pages/auth/WelcomePage.tsx
+++ b/src/pages/auth/WelcomePage.tsx
@@ -1,5 +1,17 @@
 import React from "react";
+import LogoIcon from "@/assets/logo.png";
 
 export default function WelcomePage() {
-  return <div>WelcomePage</div>;
+  return (
+    <Container>
+      <LogoWrapper>
+        <Logo src={LogoIcon} alt="Logo" />
+        <LogoText>PLIST</LogoText>
+      </LogoWrapper>
+      <MessageWrapper>
+        <WelcomeText>가입을 환영합니다!</WelcomeText>
+        <SubText>플리스트와 함께 즐거운 음악을 공유해요!</SubText>
+      </MessageWrapper>
+    </Container>
+  );
 }

--- a/src/pages/auth/WelcomePage.tsx
+++ b/src/pages/auth/WelcomePage.tsx
@@ -7,12 +7,12 @@ export default function WelcomePage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // 3초 후 메인 화면(/main)으로 이동
+    //3초 후 메인 화면(/main)으로 이동
     const timer = setTimeout(() => {
       navigate("/HomePage");
     }, 3000);
 
-    // 컴포넌트가 언마운트되면 타이머를 클리어
+    //컴포넌트가 언마운트되면 타이머를 클리어
     return () => clearTimeout(timer);
   }, [navigate]);
 
@@ -25,6 +25,7 @@ export default function WelcomePage() {
       <MessageWrapper>
         <WelcomeText>가입을 환영합니다!</WelcomeText>
         <SubText>플리스트와 함께 즐거운 음악을 공유해요!</SubText>
+        <SubText1>3초뒤 자동으로 메인화면으로 이동합니다.</SubText1>
       </MessageWrapper>
     </Container>
   );
@@ -75,4 +76,10 @@ const SubText = styled.p`
   font-size: 20px;
   color: #666;
   margin: 0;
+`;
+
+const SubText1 = styled.p`
+  font-size: 15px;
+  color: #4654a3;
+  margin: 10px;
 `;

--- a/src/pages/auth/WelcomePage.tsx
+++ b/src/pages/auth/WelcomePage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 import LogoIcon from "@/assets/logo.png";
 
 export default function WelcomePage() {
@@ -15,3 +16,50 @@ export default function WelcomePage() {
     </Container>
   );
 }
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background-color: white;
+`;
+
+const LogoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 20px;
+`;
+
+const Logo = styled.img`
+  width: 80px;
+  height: 80px;
+  margin-bottom: 8px;
+`;
+
+const LogoText = styled.h1`
+  font-size: 24px;
+  color: #4654a3;
+  font-weight: bold;
+  margin: 0;
+`;
+
+const MessageWrapper = styled.div`
+  text-align: center;
+`;
+
+const WelcomeText = styled.h2`
+  font-size: 30px;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+  margin-bottom: 8px;
+`;
+
+const SubText = styled.p`
+  font-size: 20px;
+  color: #666;
+  margin: 0;
+`;


### PR DESCRIPTION
## 작업
**welcome 페이지 UI 구현**
1. 로고 - 로고 이미지를 상단 중앙에 구현
2. 로고 텍스트 대체 - "PLIST" 텍스트를 로고 아래에 구현
3. 환영 메시지 - 큰 글씨로 "가입을 환영합니다!" / 작은 글씨로 부가 설명 텍스트 구현
4. 페이지 이동 메세지 - "3초뒤 자동으로 메인화면으로 이동합니다."

**welcome 페이지 기능 구현**
1. WelcomePage를 띄운 후 3초 뒤에 HomePage 화면으로 자동으로 이동
- setTimeout의 딜레이를 3000ms로 설정 (3초가 너무 느리면 2초로 바꿔도 가능)

## 참고 사항

1. 로고 변경
2. setTimeout 타임 정하고 변경 가능

## 관련 이슈

