### PR TITLE
FEAT: 내 플레이리스트 메인 페이지 & 상세 페이지 UI 구현

### DIFF
--- a/src/pages/mypage/PlaylistDetailPage.tsx
+++ b/src/pages/mypage/PlaylistDetailPage.tsx
@@ -1,5 +1,80 @@
-import React from "react";
+import { useParams } from "react-router-dom";
+import TopBarLayout from "@/layout/TopBarLayout";
+import { useLayoutEffect, useState } from "react";
+import { Menu, Heart } from "lucide-react";
+import AddItemButton from "./components/playlit-detail/AddItemButton";
 
 export default function PlaylistDetailPage() {
-  return <div>PlaylistDetailPage</div>;
+  const { playlistId } = useParams();
+
+  // UI 구현을 위한 임시 state -> 추후에 react-query로 변경
+  const [playlistName, setPlaylistName] = useState("");
+
+  useLayoutEffect(() => {
+    // id를 이용하여 API 호출하여 정보를 가져와 title 값을 렌더링
+    console.log(playlistId);
+    setPlaylistName(`플레이리스트 ${playlistId}`);
+  }, [playlistId]);
+
+  const mock = [
+    {
+      id: 1,
+      thumbnail: "https://picsum.photos/100/100",
+      name: "가수 - 엄청 긴 이름을 가지는 노래 제목",
+    },
+    {
+      id: 2,
+      thumbnail: "https://picsum.photos/100/100",
+      name: "가수 - 노래2",
+    },
+    {
+      id: 3,
+      thumbnail: "https://picsum.photos/100/100",
+      name: "가수 - 노래3",
+    },
+    {
+      id: 4,
+      thumbnail: "https://picsum.photos/100/100",
+      name: "가수 - 노래4",
+    },
+    {
+      id: 5,
+      thumbnail: "https://picsum.photos/100/100",
+      name: "가수 - 노래5",
+    },
+  ];
+
+  const Item = ({ item }: { item: { id: number; thumbnail: string; name: string } }) => {
+    return (
+      <div className="flex items-center gap-2 p-2 border rounded-lg">
+        <Menu className="flex-shrink-0" />
+        <div
+          className="w-10 bg-gray-200 bg-cover rounded-lg shrink-0 aspect-square"
+          style={{ backgroundImage: `url('${item.thumbnail}')` }}
+        ></div>
+        <div className="flex-grow truncate">{item.name}</div>
+        <button className="p-0 hover:border-transparent hover:text-red-main">
+          <Heart className="text-red-main" />
+        </button>
+      </div>
+    );
+  };
+
+  return (
+    <TopBarLayout
+      /* TODO: 페칭해온 이름으로 title 변경하기 */
+      topBarProps={{
+        title: playlistName,
+        backURL: "/mypage/playlist",
+        hasAction: true,
+        rightActionElement: <AddItemButton />,
+      }}
+    >
+      <section className="flex flex-col gap-2 px-5 py-6 overflow-y-auto">
+        {mock.map((item) => (
+          <Item key={item.id} item={item} />
+        ))}
+      </section>
+    </TopBarLayout>
+  );
 }

--- a/src/pages/mypage/PlaylistPage.tsx
+++ b/src/pages/mypage/PlaylistPage.tsx
@@ -1,5 +1,56 @@
-import React from "react";
+import TopBarLayout from "@/layout/TopBarLayout";
+import CreatePlaylistButton from "@/pages/mypage/components/playlist/CreatePlaylistButton";
+import PlaylistItem from "@/pages/mypage/components/playlist/PlaylistItem";
 
 export default function PlaylistPage() {
-  return <div>PlaylistPage</div>;
+  // TODO: 플레이리스트 데이터 받아오기
+  const mock = [
+    {
+      id: 1,
+      thumbnails: "https://picsum.photos/100/100",
+      title: "플레이리스트1",
+      track_count: 10,
+    },
+    {
+      id: 2,
+      thumbnails: "https://picsum.photos/100/100",
+      title: "플레이리스트2",
+      track_count: 10,
+    },
+    {
+      id: 3,
+      thumbnails: "https://picsum.photos/100/100",
+      title: "플레이리스트3",
+      track_count: 10,
+    },
+    {
+      id: 4,
+      thumbnails: "https://picsum.photos/100/100",
+      title: "플레이리스트4",
+      track_count: 10,
+    },
+    {
+      id: 5,
+      thumbnails: "https://picsum.photos/100/100",
+      title: "플레이리스트5",
+      track_count: 10,
+    },
+  ];
+
+  return (
+    <TopBarLayout
+      topBarProps={{
+        title: "내 플레이리스트",
+        backURL: "/mypage",
+        hasAction: true,
+        rightActionElement: <CreatePlaylistButton />,
+      }}
+    >
+      <section className="grid justify-between grid-cols-2 px-5 py-6 overflow-y-auto gap-x-4 gap-y-8">
+        {mock.map((item) => (
+          <PlaylistItem key={item.id} item={item} />
+        ))}
+      </section>
+    </TopBarLayout>
+  );
 }

--- a/src/pages/mypage/components/playlist/CreatePlaylistButton.tsx
+++ b/src/pages/mypage/components/playlist/CreatePlaylistButton.tsx
@@ -1,0 +1,17 @@
+import { Plus } from "lucide-react";
+import { overlay } from "overlay-kit";
+import CreatePlaylistModal from "@/pages/mypage/components/playlist/CreatePlaylistModal";
+
+export default function CreatePlaylistButton() {
+  const openModal = () => {
+    overlay.open(({ unmount }) => {
+      return <CreatePlaylistModal unmount={unmount} />;
+    });
+  };
+
+  return (
+    <button className="text-black" onClick={openModal}>
+      <Plus className="w-6 h-6" />
+    </button>
+  );
+}

--- a/src/pages/mypage/components/playlist/CreatePlaylistModal.tsx
+++ b/src/pages/mypage/components/playlist/CreatePlaylistModal.tsx
@@ -1,0 +1,51 @@
+interface CreatePlaylistModalProps {
+  unmount: () => void;
+}
+
+export default function CreatePlaylistModal({ unmount }: CreatePlaylistModalProps) {
+  // TODO: onChange와 onClick 함수 구현
+
+  return (
+    <div
+      role="button"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-10"
+      onClick={unmount}
+    >
+      <div
+        role="dialog"
+        className="relative flex flex-col w-4/5 max-w-3xl gap-8 p-5 bg-white border rounded-lg shadow-lg center border-gray-border"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="font-bold">플레이리스트 추가</header>
+
+        <div className="flex flex-col gap-2">
+          <label htmlFor="playlist-name" className="font-medium">
+            새 플레이리스트
+          </label>
+          <input
+            id="playlist-name"
+            type="text"
+            placeholder="플레이리스트 이름"
+            onChange={(e) => console.log(e.target.value)}
+            className="p-2 border rounded-lg border-gray-border"
+          />
+        </div>
+
+        <div className="flex justify-end w-full gap-2">
+          <button
+            className="px-3 py-1 rounded-lg hover:bg-black-bright hover:text-white text-border"
+            onClick={unmount}
+          >
+            취소
+          </button>
+          <button
+            className="px-3 py-1 text-black border border-black rounded-lg bg-primary-light hover:bg-primary hover:text-white"
+            onClick={() => console.log("생성")}
+          >
+            생성
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/mypage/components/playlist/CreatePlaylistModal.tsx
+++ b/src/pages/mypage/components/playlist/CreatePlaylistModal.tsx
@@ -39,7 +39,7 @@ export default function CreatePlaylistModal({ unmount }: CreatePlaylistModalProp
             취소
           </button>
           <button
-            className="px-3 py-1 text-black border border-black rounded-lg bg-primary-light hover:bg-primary hover:text-white"
+            className="px-3 py-1 text-black border border-black rounded-lg bg-primary-light hover:bg-primary hover:text-primary-main"
             onClick={() => console.log("생성")}
           >
             생성

--- a/src/pages/mypage/components/playlist/PlaylistItem.tsx
+++ b/src/pages/mypage/components/playlist/PlaylistItem.tsx
@@ -1,0 +1,48 @@
+import { useNavigate } from "react-router-dom";
+import { EllipsisVertical } from "lucide-react";
+import PlaylistItemOptionModal from "@/pages/mypage/components/playlist/PlaylistItemOptionModal";
+import { useState } from "react";
+
+interface PlaylistItemProps {
+  readonly item: { id: number; thumbnails?: string; title: string; track_count: number };
+}
+
+export default function PlaylistItem({ item }: PlaylistItemProps) {
+  const { id, thumbnails, title, track_count } = item;
+  const navigate = useNavigate();
+
+  const onClickItem = () => navigate(`${id}`);
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div
+      onClick={onClickItem}
+      className="flex flex-col w-full border rounded-md cursor-pointer border-gray-border hover:text-black"
+      aria-label={title}
+      role="button"
+    >
+      <div
+        className="relative flex w-full bg-gray-200 bg-cover aspect-square"
+        style={{ backgroundImage: `url('${thumbnails}')` }}
+      >
+        <button
+          className={`${item.id} absolute p-1 transition-all duration-300 bg-transparent top-2 right-2 hover:scale-110 hover:border-transparent hover:text-black`}
+          onClick={(e) => {
+            e.stopPropagation();
+            console.log("option clicked");
+            setIsOpen((c) => !c);
+          }}
+          onBlur={() => setIsOpen(false)}
+        >
+          <EllipsisVertical className="text-black bg-white border-black rounded-full" />
+        </button>
+        <PlaylistItemOptionModal isOpen={isOpen} playListId={id} />
+      </div>
+      <div className="flex flex-col gap-1 px-3 py-2">
+        <div className="text-base font-medium truncate">{title}</div>
+        <div className="text-sm text-gray-500">트랙 {track_count}개</div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/mypage/components/playlist/PlaylistItemOptionModal.tsx
+++ b/src/pages/mypage/components/playlist/PlaylistItemOptionModal.tsx
@@ -1,0 +1,55 @@
+import { useRef } from "react";
+
+interface PlaylistItemOptionModalProps {
+  readonly isOpen: boolean;
+  readonly playListId: number;
+}
+
+export default function PlaylistItemOptionModal({
+  isOpen,
+  playListId,
+}: PlaylistItemOptionModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const options = [
+    { optionId: 1, name: "수정하기", onClick: () => console.log(`${playListId} 수정하기`) },
+    { optionId: 2, name: "삭제하기", onClick: () => console.log(`${playListId} 삭제하기`) },
+  ];
+
+  const OptionItem = ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick: () => void;
+  }) => {
+    return (
+      <button
+        onClick={() => {
+          console.log("로직");
+          onClick();
+        }}
+        className="p-2 cursor-pointer hover:bg-gray-100 hover:border-transparent"
+      >
+        {children}
+      </button>
+    );
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          ref={modalRef}
+          className="absolute flex flex-col bg-white border border-gray-200 rounded-md shadow-lg right-2 top-10"
+        >
+          {options.map((option) => (
+            <OptionItem key={option.optionId} onClick={option.onClick}>
+              {option.name}
+            </OptionItem>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/mypage/components/playlit-detail/AddItemButton.tsx
+++ b/src/pages/mypage/components/playlit-detail/AddItemButton.tsx
@@ -1,0 +1,17 @@
+import { Plus } from "lucide-react";
+import { overlay } from "overlay-kit";
+import AddItemModal from "@/pages/mypage/components/playlit-detail/AddItemModal";
+
+export default function AddItemButton() {
+  const openModal = () => {
+    overlay.open(({ unmount }) => {
+      return <AddItemModal unmount={unmount} />;
+    });
+  };
+
+  return (
+    <button className="p-2 text-black" onClick={openModal}>
+      <Plus className="w-6 h-6" />
+    </button>
+  );
+}

--- a/src/pages/mypage/components/playlit-detail/AddItemModal.tsx
+++ b/src/pages/mypage/components/playlit-detail/AddItemModal.tsx
@@ -1,0 +1,98 @@
+import { Plus, X } from "lucide-react";
+import { useRef, useState } from "react";
+
+interface AddItemModalProps {
+  unmount: () => void;
+}
+
+export default function AddItemModal({ unmount }: AddItemModalProps) {
+  // TODO: onChange와 onClick 함수 구현
+
+  const [search, setSearch] = useState("");
+  const [searchResult, setSearchResult] = useState<
+    { id: number; title: string; url: string }[] | null
+  >(null);
+
+  const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+  };
+
+  // 목데이터
+  const mockSearchResult = [
+    { id: 1, title: "test1", url: "https://www.youtube.com/watch?v=1" },
+    { id: 2, title: "test2", url: "https://www.youtube.com/watch?v=2" },
+    { id: 3, title: "test3", url: "https://www.youtube.com/watch?v=3" },
+    { id: 4, title: "test4", url: "https://www.youtube.com/watch?v=4" },
+    { id: 5, title: "test5", url: "https://www.youtube.com/watch?v=5" },
+    { id: 6, title: "test6", url: "https://www.youtube.com/watch?v=6" },
+    { id: 7, title: "test7", url: "https://www.youtube.com/watch?v=7" },
+    { id: 8, title: "test8", url: "https://www.youtube.com/watch?v=8" },
+    { id: 9, title: "test9", url: "https://www.youtube.com/watch?v=9" },
+    { id: 10, title: "test10", url: "https://www.youtube.com/watch?v=10" },
+  ];
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    // 검색어 입력 시 검색 API 호출
+    console.log(search);
+    // 검색 결과 출력
+    setSearchResult(mockSearchResult);
+  };
+
+  // 임시 컴포넌트 (추후 수정 예정)
+  const SearchItem = ({ item }: { item: { id: number; title: string; url: string } }) => {
+    return (
+      <div className="flex flex-shrink-0 w-full p-2 border h-28 border-gray-border">
+        <div className="flex flex-col flex-grow gap-2">
+          <div className="text-sm font-bold">{item.title}</div>
+          <div className="text-xs text-gray-dark">{item.url}</div>
+        </div>
+        <button onClick={() => console.log("추가")}>
+          <Plus className="w-6 h-6 ml-auto" />
+        </button>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      role="button"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-10 animate-fadeIn pt-header"
+      onClick={unmount}
+    >
+      <div
+        role="dialog"
+        ref={dialogRef}
+        className={`relative flex flex-col w-full max-w-3xl gap-4 p-4 pt-0 mx-4 overflow-y-scroll bg-white border rounded-lg shadow-lg cursor-default transition-[height] duration-500 ease-in-out ${
+          searchResult && searchResult.length >= 2 ? "h-[80%]" : "h-1/2"
+        } border-gray-border animate-slideUp`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="sticky top-0 flex items-center justify-between pt-4 pb-2 font-bold bg-white border-b z-index-10 border-gray-border">
+          <div>Youtube 영상 추가</div>
+          <X className="w-6 h-6 cursor-pointer" onClick={unmount} />
+        </header>
+
+        <div className="flex flex-col gap-2">
+          <input
+            id="playlist-name"
+            type="text"
+            placeholder="검색어나 유튜브 URL을 입력해주세요"
+            onChange={onChangeHandler}
+            className="p-2 border rounded-lg border-gray-border"
+            onKeyDown={onKeyDownHandler}
+          />
+        </div>
+
+        {/* 검색한 결과가 나타나는 곳 */}
+        <div className="flex flex-col gap-3">
+          {searchResult?.map((item) => (
+            <SearchItem key={item.id} item={item} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,20 @@ export default {
         header: "60px",
         fnb: "72px",
       },
+      keyframes: {
+        fadeIn: {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+        slideUp: {
+          "0%": { transform: "translateY(100%)", opacity: "0" },
+          "100%": { transform: "translateY(0)", opacity: "1" },
+        },
+      },
+      animation: {
+        fadeIn: "fadeIn 0.3s ease-in-out",
+        slideUp: "slideUp 0.5s ease-out",
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## 작업

<!-- 작업 내역 작성 -->
### 플레이리스트 메인 페이지
- 전체적인 UI 구현
- + 버튼 누르면 새 재생목록 추가하는 모달창 구현
- 아이템 마다 수정/삭제를 가능하게 하는 옵션창 구현

### 플레이리스트 상세 페이지
- - 상세 페이지 UI 구현
- 플레이리스트에 목록을 추가할 수 있는 모달창 구현
- 모달창
  - 애니메이션 적용 ( 추후 다른 페이지에서도 일관적으로 적용 예정 )
  - 검색어를 입력받아 API 호출할 수 있게 UI 임시 구현
  - tailwind.config.js에 애니메이션 커스텀 class 추가

## 참고 사항

<!-- 라이브러리 설치, 작업 관련 주의 사항, 변경 사항 등등 -->

## 관련 이슈

<!-- #이슈번호 -->
<!-- PR Merge 되어 이슈 닫을 경우: Close #이슈번호 -->
#11 