### PR TITLE
FEAT: 플리방 채널 페이지 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.26.1",
     "react-spinners": "^0.15.0",
+    "react-youtube": "^10.1.0",
+    "sockjs": "^0.3.24",
     "styled-components": "^6.1.13",
     "tailwindcss": "^3.4.17"
   },

--- a/src/pages/channel/ChannelPage.tsx
+++ b/src/pages/channel/ChannelPage.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ChannelPage() {
+  return <div>ChannelPage</div>;
+}

--- a/src/pages/channel/ChannelPage.tsx
+++ b/src/pages/channel/ChannelPage.tsx
@@ -1,5 +1,26 @@
-import React from "react";
+import ChannelTopBar from "@/pages/channel/components/ChannelTopBar";
+import { useParams } from "react-router-dom";
+import { useState } from "react";
+import VideoPlayer from "@/pages/channel/components/VideoPlayer";
+import Playlist from "@/pages/channel/components/Playlist";
+import ChatArea from "@/pages/channel/components/ChatArea";
 
 export default function ChannelPage() {
-  return <div>ChannelPage</div>;
+  const { id } = useParams();
+  /* TODO: 위에서 얻은 id로 채널방 정보 가져오고 웹소켓 연결하기 */
+  const [videoId, setVideoId] = useState("2g811Eo7K8U");
+  const title = "듣기 좋은 발라드 추천 좀 해주세요";
+
+  return (
+    <div className="flex flex-col w-full h-screen overflow-hidden">
+      <ChannelTopBar title={title} />
+
+      <VideoPlayer videoId={videoId} />
+
+      <div className="flex flex-col flex-1 w-full min-h-0 bg-white">
+        <Playlist />
+        <ChatArea />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/channel/components/ChannelTopBar.tsx
+++ b/src/pages/channel/components/ChannelTopBar.tsx
@@ -1,0 +1,53 @@
+import { ChevronLeft } from "lucide-react";
+import ExitRoomModal from "@/pages/channel/components/ExitRoomModal";
+import { overlay } from "overlay-kit";
+import { GoDotFill } from "react-icons/go";
+
+export interface ChannelTopBarProps {
+  title: string;
+  rightActionElement?: React.ReactNode;
+  hasAction?: boolean;
+}
+
+const ChannelTopBar: React.FC<ChannelTopBarProps> = ({
+  title,
+  rightActionElement,
+  hasAction = false,
+}) => {
+  const openModal = () => {
+    overlay.open(({ unmount }) => {
+      return <ExitRoomModal unmount={unmount} />;
+    });
+  };
+
+  // TODO: jotai 변수로 선언하여 1초마다 업데이트 해주기
+  const streamDuration = "10:00:00";
+
+  return (
+    <div className="flex items-center justify-between flex-shrink-0 px-0 pr-4 bg-transparent bg-white border-b border-gray-200 h-header">
+      {/* 뒤로가기 버튼 */}
+      <button
+        className="flex items-center justify-center p-0 w-header h-header"
+        type="button"
+        aria-label="뒤로가기"
+        onClick={openModal}
+      >
+        <ChevronLeft />
+      </button>
+
+      {/* Title */}
+      <div className="absolute text-lg font-bold truncate transform -translate-x-1/2 left-1/2 max-w-[200px]">
+        {title}
+      </div>
+
+      {/* 우측 액션 버튼 */}
+      {hasAction && <>{rightActionElement}</>}
+      <div className="flex items-center gap-1">
+        <GoDotFill className="text-red-main" />
+        <div className="text-sm text-gray-500">{streamDuration}</div>
+      </div>
+    </div>
+  );
+};
+
+export default ChannelTopBar;

--- a/src/pages/channel/components/ChatArea.tsx
+++ b/src/pages/channel/components/ChatArea.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from "react";
+import ChatBox from "./ChatBox";
+import ChatInput from "./ChatInput";
+
+export default function ChatArea() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const mockChat = {
+    participants: [
+      { userId: 1, name: "John", thumbnail: "" },
+      { userId: 2, name: "Jane", thumbnail: "" },
+      { userId: 3, name: "Doe", thumbnail: "" },
+      { userId: 4, name: "Alice", thumbnail: "" },
+      { userId: 5, name: "Bob", thumbnail: "" },
+      { userId: 6, name: "Charlie", thumbnail: "" },
+      { userId: 7, name: "David", thumbnail: "" },
+      { userId: 8, name: "Eve", thumbnail: "" },
+      { userId: 9, name: "Frank", thumbnail: "" },
+      { userId: 10, name: "Grace", thumbnail: "" },
+    ],
+    chats: [
+      { userId: 1, message: "Hello" },
+      { userId: 2, message: "Hello" },
+      { userId: 3, message: "Hello" },
+      { userId: 4, message: "Hello" },
+      { userId: 5, message: "Hello" },
+      { userId: 6, message: "Hello" },
+      { userId: 7, message: "Hello" },
+      { userId: 8, message: "Hello" },
+      { userId: 9, message: "Hello" },
+      { userId: 10, message: "Hello" },
+    ],
+  };
+
+  const [chats, setChats] = useState(mockChat.chats);
+
+  const cachingUsername: { [key: number]: string } = {
+    1: "John",
+    2: "Jane",
+    3: "Doe",
+    4: "Alice",
+    5: "Bob",
+    6: "Charlie",
+    7: "David",
+    8: "Eve",
+    9: "Frank",
+    10: "Grace",
+  };
+
+  const cachingThumbnail: { [key: number]: string } = {
+    1: "",
+    2: "",
+    3: "",
+    4: "",
+    5: "",
+    6: "",
+    7: "",
+    8: "",
+    9: "",
+    10: "",
+  };
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [mockChat.chats]);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex flex-col flex-1 overflow-y-auto" ref={scrollRef}>
+        {chats.map((chat) => (
+          <ChatBox
+            key={chat.userId}
+            thumbnail={cachingThumbnail[chat.userId]}
+            message={chat.message}
+            username={cachingUsername[chat.userId]}
+          />
+        ))}
+      </div>
+      <ChatInput />
+    </div>
+  );
+}

--- a/src/pages/channel/components/ChatBox.tsx
+++ b/src/pages/channel/components/ChatBox.tsx
@@ -1,0 +1,20 @@
+interface ChatBoxProps {
+  thumbnail: string;
+  message: string;
+  username: string;
+}
+
+export default function ChatBox({ thumbnail, message, username }: ChatBoxProps) {
+  return (
+    <div className="flex gap-3 p-4">
+      <div
+        className="w-10 h-10 bg-cover rounded-full bg-primary-500 shrink-0 aspect-square"
+        style={{ backgroundImage: `url('${thumbnail}')` }}
+      ></div>
+      <div>
+        <div>{username}</div>
+        <div>{message}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/channel/components/ChatInput.tsx
+++ b/src/pages/channel/components/ChatInput.tsx
@@ -1,0 +1,45 @@
+import { CirclePlus, Send } from "lucide-react";
+import { overlay } from "overlay-kit";
+import { useState } from "react";
+import SearchBottomSheet from "./SearchBottomSheet";
+
+export default function ChatInput() {
+  const [message, setMessage] = useState("");
+
+  const openSearchBottomSheet = () => {
+    overlay.open(({ isOpen, unmount }) => <SearchBottomSheet isOpen={isOpen} unmount={unmount} />);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMessage(e.target.value);
+  };
+
+  const sendMessage = () => {
+    console.log(message);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      sendMessage();
+    }
+  };
+
+  return (
+    <div className="flex items-center w-full gap-2 px-1 py-2 border-t border-border">
+      <button className="p-2" onClick={openSearchBottomSheet}>
+        <CirclePlus />
+      </button>
+
+      <input
+        type="text"
+        value={message}
+        onChange={handleChange}
+        className="flex-grow px-4 py-2 border rounded-lg border-border"
+        onKeyDown={onKeyDown}
+      />
+      <button className="p-2" onClick={sendMessage}>
+        <Send />
+      </button>
+    </div>
+  );
+}

--- a/src/pages/channel/components/ExitRoomModal.tsx
+++ b/src/pages/channel/components/ExitRoomModal.tsx
@@ -1,0 +1,53 @@
+import { X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+export default function ExitRoomModal({ unmount }: { unmount: () => void }) {
+  const navigate = useNavigate();
+
+  const onClickGoBack = () => {
+    unmount();
+    navigate("../");
+  };
+
+  const onClickGoBackWithSave = () => {
+    //TODO: 재생목록 추가하는 로직 추가
+    unmount();
+    navigate("../");
+  };
+
+  return (
+    <div
+      role="button"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-30 animate-fadeIn"
+      onClick={unmount}
+    >
+      <div
+        role="dialog"
+        className={`relative flex flex-col w-full max-w-3xl gap-8 px-4 py-8 mx-4 bg-white border rounded-lg shadow-lg border-gray-border animate-fadeIn`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="relative flex items-center justify-center font-bold bg-white">
+          <div className="font-bold text-center">Youtube 영상 추가</div>
+          <X className="absolute right-0 w-6 h-6 cursor-pointer" onClick={unmount} />
+        </header>
+
+        <div className="text-center">플레이리스트를 저장하시고 나가겠어요?</div>
+
+        <div className="flex items-center justify-around w-full gap-2">
+          <button
+            className="w-1/2 p-2 px-4 text-black bg-white border border-gray-border"
+            onClick={onClickGoBack}
+          >
+            그냥 나가기
+          </button>
+          <button
+            className="w-1/2 p-2 px-4 bg-white border text-primary-main border-gray-border"
+            onClick={onClickGoBackWithSave}
+          >
+            추가하고 나가기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/channel/components/PlayListItemBox.tsx
+++ b/src/pages/channel/components/PlayListItemBox.tsx
@@ -1,0 +1,48 @@
+import { Heart, Menu } from "lucide-react";
+
+interface PlayListItemBoxProps {
+  item: {
+    id: number;
+    thumbnail: string;
+    title: string;
+  };
+  currentVideoId: number;
+  setCurrentVideoId: (id: number) => void;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+export default function PlayListItemBox({
+  item,
+  currentVideoId,
+  setCurrentVideoId,
+  setIsOpen,
+}: PlayListItemBoxProps) {
+  return (
+    <div
+      className={`flex items-center gap-2 p-2 cursor-pointer border border-border rounded-lg hover:bg-gray-100 ${
+        currentVideoId === item.id ? "bg-gray-50" : ""
+      }`}
+      onClick={() => {
+        setCurrentVideoId(item.id);
+        setIsOpen(false);
+      }}
+      draggable={true}
+    >
+      <Menu className="flex-shrink-0" />
+      <div
+        className="w-10 bg-gray-200 bg-cover rounded-lg shrink-0 aspect-square"
+        style={{ backgroundImage: `url('${item.thumbnail}')` }}
+      ></div>
+      <div className="flex-grow truncate">{item.title}</div>
+      <button
+        className="p-0 hover:border-transparent hover:text-red-main"
+        onClick={(e) => {
+          e.stopPropagation();
+          console.log("favorite clicked");
+        }}
+      >
+        <Heart className="text-red-main" />
+      </button>
+    </div>
+  );
+}

--- a/src/pages/channel/components/Playlist.tsx
+++ b/src/pages/channel/components/Playlist.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { IoMdArrowDropdown } from "react-icons/io";
+import PlayListItemBox from "./PlayListItemBox";
+
+export default function Playlist() {
+  const [playlist, setPlaylist] = useState<any[]>([
+    { id: 1, title: "먼데이키즈 - 봄 안부" },
+    { id: 2, title: "먼데이키즈 - 여름 안부" },
+    { id: 3, title: "먼데이키즈 - 가을 안부" },
+    { id: 4, title: "먼데이키즈 - 겨울 안부" },
+    { id: 5, title: "먼데이키즈 - 봄 안부" },
+    { id: 6, title: "먼데이키즈 - 여름 안부" },
+    { id: 7, title: "먼데이키즈 - 가을 안부" },
+    { id: 8, title: "먼데이키즈 - 겨울 안부" },
+    { id: 9, title: "먼데이키즈 - 봄 안부" },
+    { id: 10, title: "먼데이키즈 - 여름 안부" },
+    { id: 11, title: "먼데이키즈 - 가을 안부" },
+    { id: 12, title: "먼데이키즈 - 겨울 안부" },
+  ]);
+
+  const [currentVideoId, setCurrentVideoId] = useState(2);
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <div
+        className={`flex items-center justify-between gap-4 p-2 border-border ${
+          !isOpen ? "border-b" : ""
+        }`}
+      >
+        {!isOpen && (
+          <>
+            <div>현재 음악</div>
+            <div className="flex-1 text-base">
+              {playlist.find((item) => item.id === currentVideoId)?.title}
+            </div>
+          </>
+        )}
+
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex items-center ml-auto font-medium text-black"
+        >
+          재생목록
+          <IoMdArrowDropdown className="text-2xl" />
+        </button>
+      </div>
+
+      {isOpen && (
+        /* TODO: 드래그앤드랍 적용하기 */
+        /* TODO: 호스트가 아이템박스 클릭 시 현재 재생 영상 변경 */
+        /* TODO: 클릭하면 favorite에 추가하기 */
+        <div className="overflow-y-auto flex flex-col gap-2 px-2 py-4 absolute left-0 right-0 z-10 transition-all duration-300 ease-in-out origin-top transform bg-white border-b shadow-lg h-[calc(100vh*0.5)] top-full animate-dropdown rounded-b-lg">
+          {playlist.map((item) => (
+            <PlayListItemBox
+              key={item.id}
+              item={item}
+              currentVideoId={currentVideoId}
+              setCurrentVideoId={setCurrentVideoId}
+              setIsOpen={setIsOpen}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/channel/components/SearchBottomSheet.tsx
+++ b/src/pages/channel/components/SearchBottomSheet.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Search, CirclePlus } from "lucide-react";
+
+interface SearchBottomSheetProps {
+  isOpen: boolean;
+  unmount: () => void;
+}
+
+export default function SearchBottomSheet({ isOpen, unmount }: SearchBottomSheetProps) {
+  const [search, setSearch] = useState("");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+  };
+
+  const SearchedItem = ({ item }: { item: { id: number; thumbnail: string; title: string } }) => {
+    return (
+      <div
+        className={`flex items-center gap-3 p-2 cursor-pointer border border-border rounded-lg hover:bg-gray-100`}
+      >
+        <div
+          className="w-10 bg-gray-200 bg-cover rounded-lg shrink-0 aspect-square"
+          style={{ backgroundImage: `url('${item.thumbnail}')` }}
+        ></div>
+        <div className="flex-grow text-lg font-medium truncate">{item.title}</div>
+        <button
+          className="p-0 hover:border-transparent hover:text-red-main"
+          onClick={(e) => {
+            e.stopPropagation();
+            console.log("favorite clicked");
+          }}
+        >
+          <CirclePlus className="w-8 h-8 text-gray-light" />
+        </button>
+      </div>
+    );
+  };
+
+  return (
+    /* Overlay */
+    <div className="fixed inset-0 z-40 transition-opacity bg-black bg-opacity-50" onClick={unmount}>
+      {/* Bottom Sheet */}
+      <div
+        className={`fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl z-50 transform transition-transform duration-300 ease-out ${
+          isOpen ? "translate-y-0" : "translate-y-full"
+        } h-[calc(100vh*0.7)]`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Content */}
+        <div className="flex flex-col h-full gap-4 p-4">
+          <div className="flex items-center gap-2 p-2 border rounded-lg border-border">
+            <Search className="w-5 h-5 text-gray-400 " />
+            <input
+              type="text"
+              className="w-full outline-none"
+              value={search}
+              placeholder="검색어 또는 유튜브 링크를 입력해주세요"
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className="flex flex-col flex-1 gap-4 overflow-y-auto">
+            <h2 className="mb-1 text-xl font-bold text-center">검색 결과</h2>
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((v) => (
+              <SearchedItem key={v} item={{ id: v, thumbnail: "", title: "에일리 - 보여줄게" }} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/channel/components/VideoPlayer.tsx
+++ b/src/pages/channel/components/VideoPlayer.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import YouTube, { YouTubeProps } from "react-youtube";
+
+export default function VideoPlayer({ videoId }: { videoId: string }) {
+  /* TODO: Youtube Player로 사용할 메서드 타입 정의하기 */
+  const [player, setPlayer] = useState<any>(null);
+
+  const opts: YouTubeProps["opts"] = {
+    height: "100%",
+    width: "100%",
+    playerVars: {
+      // https://developers.google.com/youtube/player_parameters
+      autoplay: 0,
+      modestbranding: 0,
+      controls: 1,
+      fs: 1, // 전체화면 버튼 활성화
+    },
+  };
+
+  const onPlayerReady: YouTubeProps["onReady"] = (event) => {
+    setPlayer(event.target);
+    console.log("플레이어가 준비되었습니다.", event.target, typeof event.target);
+  };
+
+  const onCLickPlay = () => {
+    const playerState = player.getPlayerState();
+    /* state 참고: https://developers.google.com/youtube/iframe_api_reference?hl=ko#getPlayerState */
+    if (playerState !== 1) player.playVideo();
+    else player.pauseVideo();
+  };
+
+  return (
+    <div className="relative w-full aspect-video">
+      {/* Host를 제외하고 화면 클릭 못하게 막는 임시 레이어 */}
+      {/* <div className="absolute z-10 w-full bg-transparent aspect-video"></div> */}
+
+      <YouTube
+        videoId={videoId}
+        opts={opts}
+        onReady={onPlayerReady}
+        className="absolute top-0 left-0 w-full h-full"
+        iframeClassName="w-full h-full"
+      />
+    </div>
+  );
+}

--- a/src/pages/room/RoomPage.tsx
+++ b/src/pages/room/RoomPage.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export default function RoomPage() {
-  return <div>RoomPage</div>;
-}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -7,7 +7,7 @@ const RedirectPage = lazy(() => import("@/pages/auth/RedirectPage"));
 const WelcomePage = lazy(() => import("@/pages/auth/WelcomePage"));
 const CategoryPage = lazy(() => import("@/pages/category/CategoryPage"));
 const SearchPage = lazy(() => import("@/pages/search/SearchPage"));
-const RoomPage = lazy(() => import("@/pages/room/RoomPage"));
+const ChannelPage = lazy(() => import("@/pages/channel/ChannelPage"));
 const MyPage = lazy(() => import("@/pages/mypage/MyPage"));
 const ProfilePage = lazy(() => import("@/pages/mypage/ProfilePage"));
 const PlaylistPage = lazy(() => import("@/pages/mypage/PlaylistPage"));
@@ -33,7 +33,7 @@ const Router = () => {
 
         <Route path="/search" element={<SearchPage />} />
 
-        <Route path="/room/:roomId" element={<RoomPage />} />
+        <Route path="/channel/:channelId" element={<ChannelPage />} />
 
         <Route path="/mypage">
           <Route index element={<MyPage />} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,10 +49,15 @@ export default {
           "0%": { transform: "translateY(100%)", opacity: "0" },
           "100%": { transform: "translateY(0)", opacity: "1" },
         },
+        dropdown: {
+          "0%": { opacity: "0", transform: "scaleY(0)" },
+          "100%": { opacity: "1", transform: "scaleY(1)" },
+        },
       },
       animation: {
         fadeIn: "fadeIn 0.5s ease-in-out",
         slideUp: "slideUp 0.5s ease-out",
+        dropdown: "dropdown 0.3s ease-in-out forwards",
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,7 +51,7 @@ export default {
         },
       },
       animation: {
-        fadeIn: "fadeIn 0.3s ease-in-out",
+        fadeIn: "fadeIn 0.5s ease-in-out",
         slideUp: "slideUp 0.5s ease-out",
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,13 @@ dayjs@^1.11.10, dayjs@^1.11.13:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
+debug@^2.6.6:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
@@ -1632,7 +1639,7 @@ eta@^3.5.0:
   resolved "https://registry.yarnpkg.com/eta/-/eta-3.5.0.tgz#b728b2d4aa3cbce9d08db638719a60b31d2b0ccf"
   integrity sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -1664,6 +1671,13 @@ fastq@^1.6.0:
   integrity sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==
   dependencies:
     reusify "^1.0.4"
+
+faye-websocket@^0.11.3:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
+  integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
+  dependencies:
+    websocket-driver ">=0.5.1"
 
 file-entry-cache@^8.0.0:
   version "8.0.0"
@@ -1819,6 +1833,11 @@ headers-polyfill@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
   integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
+
+http-parser-js@>=0.5.1:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
+  integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
 
 http-status-emojis@^2.2.0:
   version "2.2.0"
@@ -2009,6 +2028,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -2021,7 +2045,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-loose-envify@^1.1.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2118,6 +2142,11 @@ mrmime@^2.0.0:
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"
   integrity sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -2199,7 +2228,7 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -2394,6 +2423,15 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prop-types@15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -2441,6 +2479,11 @@ react-infinite-scroll-component@^6.1.0:
   dependencies:
     throttle-debounce "^2.1.0"
 
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
@@ -2465,6 +2508,15 @@ react-spinners@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.15.0.tgz#bb9536a3839ab4e1513bb98847d79cc1fc930b93"
   integrity sha512-ZO3/fNB9Qc+kgpG3SfdlMnvTX6LtLmTnOogb3W6sXIaU/kZ1ydEViPfZ06kSOaEsor58C/tzXw2wROGQu3X2pA==
+
+react-youtube@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/react-youtube/-/react-youtube-10.1.0.tgz#7e5670c764f12eb408166e8eb438d788dc64e8b5"
+  integrity sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg==
+  dependencies:
+    fast-deep-equal "3.1.3"
+    prop-types "15.8.1"
+    youtube-player "5.5.2"
 
 react@^18.3.1:
   version "18.3.1"
@@ -2561,6 +2613,11 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-buffer@>=5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 scheduler@^0.23.2:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
@@ -2609,6 +2666,11 @@ sirv@^2.0.4:
     mrmime "^2.0.0"
     totalist "^3.0.0"
 
+sister@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sister/-/sister-3.0.2.tgz#bb3e39f07b1f75bbe1945f29a27ff1e5a2f26be4"
+  integrity sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==
+
 snake-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
@@ -2616,6 +2678,15 @@ snake-case@^3.0.4:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
+
+sockjs@^0.3.24:
+  version "0.3.24"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
+  integrity sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==
+  dependencies:
+    faye-websocket "^0.11.3"
+    uuid "^8.3.2"
+    websocket-driver "^0.7.4"
 
 sort-on@^6.1.0:
   version "6.1.0"
@@ -2933,6 +3004,11 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 vite-plugin-svgr@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/vite-plugin-svgr/-/vite-plugin-svgr-4.3.0.tgz#742f16f11375996306c696ec323e4d23f6005075"
@@ -2952,6 +3028,20 @@ vite@^5.4.1:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
+  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  dependencies:
+    http-parser-js ">=0.5.1"
+    safe-buffer ">=5.1.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 which@^2.0.1:
   version "2.0.2"
@@ -3043,3 +3133,12 @@ yoctocolors-cjs@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
+
+youtube-player@5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
+  integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
+  dependencies:
+    debug "^2.6.6"
+    load-script "^1.0.0"
+    sister "^3.0.0"


### PR DESCRIPTION
## 작업

<!-- 작업 내역 작성 -->
### 패키지 추가
- 유튜브 플레이어를 위한 react-youtube 설치
- 웹소켓 미지원 브라우저를 위한 sockjs 설치

### 플리방
- Route와 페이지명을 Roome에서 Channel로 수정
- 플리방 UI를 4구역으로 컴포넌트 나누어서 구현
  - 채널 탑바
  - 비디오 플레이어
  - 재생목록
  - 채팅영역
- 노래 검색을 위한 바텀시트 구현

## 참고 사항

<!-- 라이브러리 설치, 작업 관련 주의 사항, 변경 사항 등등 -->
### **라이브러리 설치로 인해 `yarn install` 필수**

## 관련 이슈

<!-- #이슈번호 -->
<!-- PR Merge 되어 이슈 닫을 경우: Close #이슈번호 -->
