### PR TITLE
유저 정보를 전역으로 갖도록 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   },
   "dependencies": {
     "@stomp/stompjs": "^7.0.0",
+    "@tanstack/query-core": "^5.64.1",
     "@tanstack/react-query": "^5.62.11",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.9",
     "dayjs": "^1.11.13",
     "jotai": "^2.9.3",
+    "jotai-tanstack-query": "^0.9.0",
     "lucide-react": "^0.469.0",
     "overlay-kit": "^1.4.1",
     "postcss": "^8.4.49",

--- a/src/layout/HeaderButton.tsx
+++ b/src/layout/HeaderButton.tsx
@@ -1,11 +1,24 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { useAtomValue } from "jotai";
+import { userProfileAtom } from "@/store/user-profile";
 
 export default function HeaderButton() {
   // Access token 가져오기
-  const accessToken = localStorage.getItem("access_token");
 
-  return <>{!accessToken && <StyledButton to={"/auth/login"}>로그인</StyledButton>}</>;
+  const userProfile = useAtomValue(userProfileAtom);
+
+  return (
+    <>
+      {!userProfile.data ? (
+        <StyledButton to={"/auth/login"}>로그인</StyledButton>
+      ) : (
+        <StyledButton to={"/mypage"} className="truncate">
+          {userProfile.data?.nickname}
+        </StyledButton>
+      )}
+    </>
+  );
 }
 
 const StyledButton = styled(Link)`

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import styled from "styled-components";
 import LogoIcon from "@/assets/svg/logo.svg";
 import TextLogoIcon from "@/assets/svg/text-logo.svg";
@@ -11,20 +11,20 @@ import { instance } from "@/services/api/instance";
 const queryClient = new QueryClient();
 
 // API 호출 함수 (유저 정보 가져오기)
-const fetchUserData = async (accessToken: string) => {
-  const response = await instance.get("/users/1", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-  return response.data;
+const fetchUserData = async () => {
+  try {
+    const response = await instance.get("/user/profile");
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 // 유저 정보를 가져오는 React Query 훅
 function useUserData(accessToken: string) {
   return useQuery({
     queryKey: ["userData", accessToken],
-    queryFn: () => fetchUserData(accessToken),
+    queryFn: () => fetchUserData(),
     enabled: !!accessToken, // accessToken이 있을 때만 쿼리 실행
   });
 }

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -4,7 +4,7 @@ import LogoIcon from "@/assets/svg/logo.svg";
 import TextLogoIcon from "@/assets/svg/text-logo.svg";
 import { ScaleLoader } from "react-spinners";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useGetUserData } from "./hooks/useGetUserData";
+import { useGetUserData } from "@/pages/auth/hooks/useGetUserData";
 
 export default function RedirectPage() {
   const navigate = useNavigate();
@@ -31,9 +31,9 @@ export default function RedirectPage() {
     // 유저 데이터가 성공적으로 로드된 후 페이지 이동
     if (user) {
       if (isMember === "true") {
-        //navigate("/"); // 홈페이지로 이동
+        navigate("/"); // 홈페이지로 이동
       } else {
-        //navigate("/auth/welcome"); // Welcome 페이지로 이동
+        navigate("/auth/welcome"); // Welcome 페이지로 이동
       }
     }
   }, [user, isMember, navigate]);

--- a/src/pages/auth/RedirectPage.tsx
+++ b/src/pages/auth/RedirectPage.tsx
@@ -4,30 +4,7 @@ import LogoIcon from "@/assets/svg/logo.svg";
 import TextLogoIcon from "@/assets/svg/text-logo.svg";
 import { ScaleLoader } from "react-spinners";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useQuery, QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { instance } from "@/services/api/instance";
-
-// React Query Client 생성
-const queryClient = new QueryClient();
-
-// API 호출 함수 (유저 정보 가져오기)
-const fetchUserData = async () => {
-  try {
-    const response = await instance.get("/user/profile");
-    return response.data;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
-// 유저 정보를 가져오는 React Query 훅
-function useUserData(accessToken: string) {
-  return useQuery({
-    queryKey: ["userData", accessToken],
-    queryFn: () => fetchUserData(),
-    enabled: !!accessToken, // accessToken이 있을 때만 쿼리 실행
-  });
-}
+import { useGetUserData } from "./hooks/useGetUserData";
 
 export default function RedirectPage() {
   const navigate = useNavigate();
@@ -38,7 +15,7 @@ export default function RedirectPage() {
   const isMember = searchParams.get("is-member");
 
   // React Query를 사용하여 유저 데이터 가져오기
-  const { data: user, isLoading, isError } = useUserData(accessToken || "");
+  const { data: user, isLoading, isError } = useGetUserData(accessToken ?? "");
 
   useEffect(() => {
     if (!accessToken || !isMember) {
@@ -54,9 +31,9 @@ export default function RedirectPage() {
     // 유저 데이터가 성공적으로 로드된 후 페이지 이동
     if (user) {
       if (isMember === "true") {
-        navigate("/"); // 홈페이지로 이동
+        //navigate("/"); // 홈페이지로 이동
       } else {
-        navigate("/auth/welcome"); // Welcome 페이지로 이동
+        //navigate("/auth/welcome"); // Welcome 페이지로 이동
       }
     }
   }, [user, isMember, navigate]);
@@ -90,15 +67,6 @@ export default function RedirectPage() {
   }
 
   return null;
-}
-
-// 앱 전체에 React Query Provider 적용
-export function AppWithQueryProvider() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <RedirectPage />
-    </QueryClientProvider>
-  );
 }
 
 const Container = styled.div`

--- a/src/pages/auth/hooks/useGetUserData.ts
+++ b/src/pages/auth/hooks/useGetUserData.ts
@@ -1,0 +1,24 @@
+import { instance } from "@/services/api/instance";
+import { useQuery } from "@tanstack/react-query";
+
+// API 호출 함수 (유저 정보 가져오기)
+const fetchUserData = async () => {
+  try {
+    const response = await instance.get("/user/profile");
+
+    console.log(response);
+
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 유저 정보를 가져오는 React Query 훅
+export function useGetUserData(accessToken: string) {
+  return useQuery({
+    queryKey: ["userData", accessToken],
+    queryFn: () => fetchUserData(),
+    enabled: !!accessToken, // accessToken이 있을 때만 쿼리 실행
+  });
+}

--- a/src/pages/auth/hooks/useGetUserData.ts
+++ b/src/pages/auth/hooks/useGetUserData.ts
@@ -15,7 +15,7 @@ export const fetchUserData = async () => {
 // 유저 정보를 가져오는 React Query 훅
 export function useGetUserData(accessToken: string) {
   return useQuery({
-    queryKey: ["userData", accessToken],
+    queryKey: ["userProfile", accessToken],
     queryFn: () => fetchUserData(),
     enabled: !!accessToken, // accessToken이 있을 때만 쿼리 실행
   });

--- a/src/pages/auth/hooks/useGetUserData.ts
+++ b/src/pages/auth/hooks/useGetUserData.ts
@@ -2,11 +2,9 @@ import { instance } from "@/services/api/instance";
 import { useQuery } from "@tanstack/react-query";
 
 // API 호출 함수 (유저 정보 가져오기)
-const fetchUserData = async () => {
+export const fetchUserData = async () => {
   try {
     const response = await instance.get("/user/profile");
-
-    console.log(response);
 
     return response.data;
   } catch (error) {

--- a/src/store/user-profile.ts
+++ b/src/store/user-profile.ts
@@ -1,0 +1,8 @@
+import { atomWithQuery } from "jotai-tanstack-query";
+import { fetchUserData } from "@/pages/auth/hooks/useGetUserData";
+
+export const userProfileAtom = atomWithQuery(() => ({
+  queryKey: ["userData", localStorage.getItem("access_token")],
+  queryFn: () => fetchUserData(),
+  enabled: !!localStorage.getItem("access_token"),
+}));

--- a/src/store/user-profile.ts
+++ b/src/store/user-profile.ts
@@ -2,7 +2,7 @@ import { atomWithQuery } from "jotai-tanstack-query";
 import { fetchUserData } from "@/pages/auth/hooks/useGetUserData";
 
 export const userProfileAtom = atomWithQuery(() => ({
-  queryKey: ["userData", localStorage.getItem("access_token")],
+  queryKey: ["userProfile", localStorage.getItem("access_token")],
   queryFn: () => fetchUserData(),
   enabled: !!localStorage.getItem("access_token"),
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,6 +873,11 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.62.9.tgz#94231ffea5de086b5e6c0f1e527cda5650cb1849"
   integrity sha512-lwePd8hNYhyQ4nM/iRQ+Wz2cDtspGeZZHFZmCzHJ7mfKXt+9S301fULiY2IR2byJYY6Z03T427E5PoVfMexHjw==
 
+"@tanstack/query-core@^5.64.1":
+  version "5.64.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.64.1.tgz#d56e26b3e29fc68a89d140f1fd92900bc8f3fc86"
+  integrity sha512-978Wx4Wl4UJZbmvU/rkaM9cQtXXrbhK0lsz/UZhYIbyKYA8E4LdomTwyh2GHZ4oU0BKKoDH4YlKk2VscCUgNmg==
+
 "@tanstack/react-query@^5.62.11":
   version "5.62.11"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.62.11.tgz#95a615a60dc8fd836a5085dea2739a62f4953f55"
@@ -2101,6 +2106,11 @@ jiti@^1.21.6:
   version "1.21.7"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
+
+jotai-tanstack-query@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/jotai-tanstack-query/-/jotai-tanstack-query-0.9.0.tgz#f3c4f96c2ec88f6fdd0b39a1d2eca6a10a8878d6"
+  integrity sha512-8n7/xV14+ZE63dyqngtmqs6aV1bNnQJF9bJN5Bj70USc2cMFRmsVhGGzL1cSvp5E/xXasU37czFFaZ0vavmyfA==
 
 jotai@^2.9.3:
   version "2.11.0"


### PR DESCRIPTION
## 작업

- 유저 정보 조회 API 엔드포인트 수정
- 유저 정보 조회 API를 외부 Hook으로 분리
- jotai-tanstack-query 사용하여 jotai에 useQuery 페칭
- 쿼리 키 이름 변경
- 헤더 컴포넌트에 적용

<!-- 작업 내역 작성 -->

## 참고 사항

<!-- 라이브러리 설치, 작업 관련 주의 사항, 변경 사항 등등 -->
**yarn install 필수**

## 관련 이슈

<!-- #이슈번호 -->
<!-- PR Merge 되어 이슈 닫을 경우: Close #이슈번호 -->
#54 
