### PR TITLE
유저플레이리스트 전체 목록 조회를 무한 스크롤로 변경

### DIFF
--- a/src/pages/mypage/PlaylistPage.tsx
+++ b/src/pages/mypage/PlaylistPage.tsx
@@ -4,10 +4,16 @@ import PlaylistItem from "@/pages/mypage/components/playlist/PlaylistItem";
 import PlaylistSkeleton from "@/pages/mypage/components/playlist/PlaylistSkeleton";
 import usePlaylist from "@/pages/mypage/hooks/usePlaylist";
 import { useDebounce } from "@/common/hooks/useDebounce";
+import InfiniteScroll from "react-infinite-scroll-component";
 
 export default function PlaylistPage() {
-  const { getMyPlaylistsQuery } = usePlaylist();
-  const debouncedLoading = useDebounce(getMyPlaylistsQuery.isLoading, 1000);
+  const {
+    getMyPlaylistsQuery: { data, hasNextPage, isLoading, fetchNextPage },
+  } = usePlaylist();
+  const debouncedLoading = useDebounce(isLoading, 500);
+
+  const content = data?.pages.flatMap((page) => page.content) ?? [];
+  const dataLength = content.length;
 
   return (
     <TopBarLayout
@@ -18,15 +24,21 @@ export default function PlaylistPage() {
         rightActionElement: <CreatePlaylistButton />,
       }}
     >
-      <section className="grid justify-between grid-cols-2 px-5 py-6 overflow-y-auto gap-x-4 gap-y-4">
-        {debouncedLoading ? (
-          <PlaylistSkeleton />
-        ) : (
-          getMyPlaylistsQuery.data?.map((item) => (
-            <PlaylistItem key={item.userPlaylistId} item={item} />
-          ))
-        )}
-      </section>
+      <InfiniteScroll
+        dataLength={dataLength}
+        next={fetchNextPage}
+        hasMore={hasNextPage}
+        loader={<p className="p-1 text-center">플레이리스트를 가져오는 중입니다...</p>}
+        endMessage={<p className="text-center"></p>}
+      >
+        <section className="grid justify-between grid-cols-2 px-5 py-6 overflow-y-auto gap-x-4 gap-y-4">
+          {debouncedLoading ? (
+            <PlaylistSkeleton />
+          ) : (
+            content.map((item) => <PlaylistItem key={item.userPlaylistId} item={item} />)
+          )}
+        </section>
+      </InfiniteScroll>
     </TopBarLayout>
   );
 }

--- a/src/services/api/userAPI.ts
+++ b/src/services/api/userAPI.ts
@@ -48,8 +48,16 @@ const userAPI = {
     return response;
   },
 
-  getMyPlaylists: async () => {
-    const { data: response } = await instance.get<MyPlaylists>(`${userPrefix}/playlists`);
+  getMyPlaylists: async ({
+    cursorId = undefined,
+    size = 20,
+  }: {
+    cursorId?: number;
+    size?: number;
+  }) => {
+    const { data: response } = await instance.get<MyPlaylists>(`${userPrefix}/playlists`, {
+      params: { cursorId, size },
+    });
 
     return response;
   },

--- a/src/types/playlist.d.ts
+++ b/src/types/playlist.d.ts
@@ -5,4 +5,7 @@ declare interface IPlaylist {
   videoCount: number;
 }
 
-declare type MyPlaylists = IPlaylist[];
+declare interface MyPlaylists {
+  content: IPlaylist[];
+  hasNext: boolean;
+}


### PR DESCRIPTION
## 작업

<!-- 작업 내역 작성 -->

- 무한스크롤로 변경된 스펙에 맞게 타입 변경
- 기존의 단일 페칭 쿼리에서 무한 스크롤 쿼리로 페칭 훅 로직 변경
- InfiniteScroll 컴포넌트를 사용하여 무한스크롤 페이지 구현

## 참고 사항

<!-- 라이브러리 설치, 작업 관련 주의 사항, 변경 사항 등등 -->

## 관련 이슈

<!-- #이슈번호 -->
<!-- PR Merge 되어 이슈 닫을 경우: Close #이슈번호 -->
