### PR TITLE
94 팔로우 푸시 알림 기능 구현

### DIFF
--- a/src/pages/mypage/FollowIngListPage.tsx
+++ b/src/pages/mypage/FollowIngListPage.tsx
@@ -1,5 +1,122 @@
-import React from "react";
+import TopBarLayout from "@/layout/TopBarLayout";
+import styled from "styled-components";
+
 
 export default function FollowIngListPage() {
   return <div>FollowIngListPage</div>;
+  return (
+    <TopBarLayout
+      topBarProps={{
+        title: "내가 구독한 구독자",
+        backURL: "/mypage",
+        hasAction: true,
+      }}
+    >
+      <List>
+        {subscribedUsers.map((user) => (
+          <UserItem key={user.id}>
+            <ColorDot
+              style={{ backgroundColor: user.color }}
+              onClick={() => handleUserClick(user.id)}
+            />
+            <UserName onClick={() => handleUserClick(user.id)}>{user.name}</UserName>
+            <SubscribeButton
+              onClick={() => handleSubscribeClick(user.id)}
+              isSubscribed={user.isSubscribed}
+            >
+              {user.isSubscribed ? "구독중" : "구독하기"}
+            </SubscribeButton>
+          </UserItem>
+        ))}
+      </List>
+
+      {showConfirmModal && (
+        <Modal>
+          <ModalText>구독을 취소하시겠습니까?</ModalText>
+          <ModalButtons>
+            <button onClick={() => setShowConfirmModal(false)}>취소</button>
+            <button onClick={confirmUnsubscribe}>구독 취소</button>
+          </ModalButtons>
+        </Modal>
+      )}
+    </TopBarLayout>
+  );
 }
+
+const List = styled.div``;
+
+const UserItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  border-bottom: 1px solid #eee;
+`;
+
+const ColorDot = styled.div`
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  margin-left: 20px;
+  cursor: pointer;
+`;
+
+const UserName = styled.div`
+  display: flex;
+  font-size: 16px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`;
+
+const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
+  padding: 6px 12px;
+  margin-right: 20px;
+  background: ${({ isSubscribed }) => (isSubscribed ? "#4854a2" : "#ffffff")};
+  color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
+  border: 1px solid #4854a2;
+  border-radius: 8px;
+  cursor: pointer;
+  justify-content: center;
+
+  &:hover {
+    color: #ffffff;
+    background-color: #6981c8;
+  }
+`;
+
+const Modal = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 24px;
+  z-index: 100;
+`;
+
+const ModalText = styled.div`
+  margin-bottom: 16px;
+`;
+
+const ModalButtons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  button {
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+`;
+
+const ClickableArea = styled.div`
+  display: flex;
+  align-items: center;
+
+  gap: 12px;
+  cursor: pointer;
+  flex: 1;
+`;

--- a/src/pages/mypage/FollowIngListPage.tsx
+++ b/src/pages/mypage/FollowIngListPage.tsx
@@ -1,9 +1,58 @@
+import React, { useState } from "react";
 import TopBarLayout from "@/layout/TopBarLayout";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 
+interface SubscribedUser {
+  id: number;
+  name: string;
+  color: string;
+  isSubscribed: boolean;
+}
+
+const mockData: SubscribedUser[] = [
+  { id: 1, name: "노지훈", color: "#3366FF", isSubscribed: true },
+  { id: 2, name: "이은선", color: "#CC33FF", isSubscribed: true },
+  { id: 3, name: "윤학수", color: "#557A00", isSubscribed: true },
+];
 
 export default function FollowIngListPage() {
-  return <div>FollowIngListPage</div>;
+  const [subscribedUsers, setSubscribedUsers] = useState<SubscribedUser[]>(mockData);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+  const navigate = useNavigate();
+
+  const handleUserClick = (userId: number) => {
+    navigate(`/user/${userId}`);
+  };
+
+  const handleSubscribeClick = (userId: number) => {
+    const user = subscribedUsers.find((u) => u.id === userId);
+    if (!user) return;
+
+    if (user.isSubscribed) {
+      setSelectedUserId(userId);
+      setShowConfirmModal(true);
+    } else {
+      updateSubscription(userId, true);
+    }
+  };
+
+  const updateSubscription = (userId: number, subscribed: boolean) => {
+    const updatedList = subscribedUsers.map((user) =>
+      user.id === userId ? { ...user, isSubscribed: subscribed } : user
+    );
+    setSubscribedUsers(updatedList);
+  };
+
+  const confirmUnsubscribe = () => {
+    if (selectedUserId !== null) {
+      updateSubscription(selectedUserId, false);
+      setSelectedUserId(null);
+      setShowConfirmModal(false);
+    }
+  };
+
   return (
     <TopBarLayout
       topBarProps={{

--- a/src/pages/mypage/FollowIngListPage.tsx
+++ b/src/pages/mypage/FollowIngListPage.tsx
@@ -160,12 +160,3 @@ const ModalButtons = styled.div`
     cursor: pointer;
   }
 `;
-
-const ClickableArea = styled.div`
-  display: flex;
-  align-items: center;
-
-  gap: 12px;
-  cursor: pointer;
-  flex: 1;
-`;

--- a/src/pages/mypage/FollowIngListPage.tsx
+++ b/src/pages/mypage/FollowIngListPage.tsx
@@ -71,7 +71,7 @@ export default function FollowIngListPage() {
             <UserName onClick={() => handleUserClick(user.id)}>{user.name}</UserName>
             <SubscribeButton
               onClick={() => handleSubscribeClick(user.id)}
-              isSubscribed={user.isSubscribed}
+              $isSubscribed={user.isSubscribed}
             >
               {user.isSubscribed ? "구독중" : "구독하기"}
             </SubscribeButton>

--- a/src/pages/mypage/FollowIngListPage.tsx
+++ b/src/pages/mypage/FollowIngListPage.tsx
@@ -118,14 +118,15 @@ const UserName = styled.div`
   cursor: pointer;
 `;
 
-const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
-  padding: 6px 12px;
+const SubscribeButton = styled.button<{ $isSubscribed: boolean }>`
   margin-right: 20px;
-  background: ${({ isSubscribed }) => (isSubscribed ? "#4854a2" : "#ffffff")};
-  color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
+  padding: 6px 12px;
+  background: ${({ $isSubscribed }) => ($isSubscribed ? "#4854a2" : "#ffffff")};
+  color: ${({ $isSubscribed }) => ($isSubscribed ? "#ffffff" : "#4854a2")};
   border: 1px solid #4854a2;
   border-radius: 8px;
   cursor: pointer;
+  display: flex;
   justify-content: center;
 
   &:hover {

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -106,7 +106,7 @@ export default function SearchPage() {
             <SubscriberText>구독자 {result.channelParticipantCount}명</SubscriberText>
           </ChannelInfo>
 
-          <SubscribeButton onClick={handleSubscribeClick} isSubscribed={isSubscribed}>
+          <SubscribeButton onClick={handleSubscribeClick} $isSubscribed={isSubscribed}>
             {isSubscribed ? "구독중" : "구독하기"}
           </SubscribeButton>
           {/* 구독 상태는 상태값에 따라 조건부로 처리 가능 */}

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -214,11 +214,11 @@ const SubscriberText = styled.p`
   color: #666;
 `;
 
-const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
+const SubscribeButton = styled.button<{ $isSubscribed: boolean }>`
   margin-right: 20px;
   padding: 6px 12px;
-  background: ${({ isSubscribed }) => (isSubscribed ? "#4854a2" : "#ffffff")};
-  color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
+  background: ${({ $isSubscribed }) => ($isSubscribed ? "#4854a2" : "#ffffff")};
+  color: ${({ $isSubscribed }) => ($isSubscribed ? "#ffffff" : "#4854a2")};
   border: 1px solid #4854a2;
   border-radius: 8px;
   cursor: pointer;

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import styled from "styled-components";
 import { IoIosSearch } from "react-icons/io";
-import StreamCard from "@/common/components/StreamCard";
 import { instance } from "@/services/api/instance";
+import { useNavigate } from "react-router-dom";
 
 // 검색 결과 타입 정의
 interface SearchResult {
@@ -11,7 +11,7 @@ interface SearchResult {
   channelCategoryName: string;
   channelThumbnail: string;
   channelStreamingTime: string;
-  channelCreatedAt: string; // timestampz 데이터
+  channelCreatedAt: string;
   channelStatus: string;
   channelHostName: string;
   channelParticipantCount: number;
@@ -20,7 +20,27 @@ interface SearchResult {
 export default function SearchPage() {
   const [searchQuery, setSearchQuery] = useState<string>(""); // 검색어
   const [results, setResults] = useState<SearchResult[] | null>(null); // 검색 결과
-  const [loading, setLoading] = useState<boolean>(false); // 로딩 상태
+  const [, setLoading] = useState<boolean>(false); // 로딩 상태
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const navigate = useNavigate();
+
+  const handleUserClick = (userId: string | number) => {
+    navigate(`/user/${userId}`);
+  };
+
+  const handleSubscribeClick = () => {
+    if (isSubscribed) {
+      setShowConfirmModal(true);
+    } else {
+      setIsSubscribed(true);
+    }
+  };
+
+  const confirmUnsubscribe = () => {
+    setIsSubscribed(false);
+    setShowConfirmModal(false);
+  };
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return; // 입력값이 공백이거나 비어 있을 경우 API 호출 X
@@ -49,13 +69,11 @@ export default function SearchPage() {
     }
   };
 
-  const noResults = results && results.length === 0;
-
   return (
     <Container>
       <SearchBarContainer>
         <SearchInput
-          placeholder="채널명, 카테고리, 호스트명을 검색해주세요."
+          placeholder="닉네임을 검색해주세요."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           onKeyDown={handleKeyDown} // Enter 키 이벤트 핸들러 추가
@@ -67,17 +85,42 @@ export default function SearchPage() {
 
       <Line />
 
-      {/* 검색 결과 */}
-      {loading ? (
-        <LoadingText>로딩 중...</LoadingText>
-      ) : noResults ? (
-        <ResultText>검색 결과가 없습니다.</ResultText> // 검색 결과가 없을 경우 메시지
-      ) : (
-        <ResultsContainer>
-          {results?.map((result) => (
-            <StreamCard key={result.channelId} item={result} /> // 검색된 채널을 StreamCard에 전달
-          ))}
-        </ResultsContainer>
+      {results?.map((result) => (
+        <ChannelCard key={result.channelId}>
+          <AvatarWrapper>
+            <AvatarImage
+              src={result.channelThumbnail}
+              onClick={() => handleUserClick(result.channelId)}
+              style={{ cursor: "pointer" }}
+            />
+            {result.channelStatus === "ON_AIR" && <LiveBadge>Live</LiveBadge>}
+          </AvatarWrapper>
+
+          <ChannelInfo>
+            <ChannelName
+              onClick={() => handleUserClick(result.channelId)}
+              style={{ cursor: "pointer" }}
+            >
+              {result.channelHostName}
+            </ChannelName>
+            <SubscriberText>구독자 {result.channelParticipantCount}명</SubscriberText>
+          </ChannelInfo>
+
+          <SubscribeButton onClick={handleSubscribeClick} isSubscribed={isSubscribed}>
+            {isSubscribed ? "구독중" : "구독하기"}
+          </SubscribeButton>
+          {/* 구독 상태는 상태값에 따라 조건부로 처리 가능 */}
+        </ChannelCard>
+      ))}
+
+      {showConfirmModal && (
+        <Modal>
+          <ModalText>구독을 취소하시겠습니까?</ModalText>
+          <ModalButtons>
+            <button onClick={() => setShowConfirmModal(false)}>취소</button>
+            <button onClick={confirmUnsubscribe}>구독 취소</button>
+          </ModalButtons>
+        </Modal>
       )}
     </Container>
   );
@@ -111,18 +154,6 @@ const Line = styled.div`
   width: 100%;
   height: 1px;
   background-color: #ddd;
-  //margin: 16px 0 0 0;
-`;
-
-const ResultsContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 20px;
-`;
-
-const LoadingText = styled.p`
-  text-align: center;
-  color: #888;
 `;
 
 const SearchInput = styled.input`
@@ -133,11 +164,96 @@ const SearchInput = styled.input`
   padding: 4px;
 `;
 
-const ResultText = styled.p`
-  margin-top: 16px;
-  font-size: 15px;
-  color: #888;
+const ChannelCard = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+`;
+
+const AvatarWrapper = styled.div`
+  position: relative;
+  margin-right: 12px;
+`;
+
+const AvatarImage = styled.img`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid #ddd;
+  object-fit: cover;
+  margin-left: 20px;
+`;
+
+const LiveBadge = styled.span`
+  position: absolute;
+  bottom: -5px;
+  left: 0;
+  background-color: red;
+  color: white;
+  font-size: 10px;
+  padding: 2px 4px;
+  border-radius: 4px;
+`;
+
+const ChannelInfo = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;
+
+const ChannelName = styled.p`
+  font-weight: 600;
+  color: #333;
+`;
+
+const SubscriberText = styled.p`
+  font-size: 14px;
+  color: #666;
+`;
+
+const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
+  margin-right: 20px;
+  padding: 6px 12px;
+  background: ${({ isSubscribed }) => (isSubscribed ? "#4854a2" : "#ffffff")};
+  color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
+  border: 1px solid #4854a2;
+  border-radius: 8px;
+  cursor: pointer;
   display: flex;
   justify-content: center;
-  align-items: center;
+
+  &:hover {
+    color: #ffffff;
+    background-color: #6981c8;
+  }
+`;
+
+const Modal = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 24px;
+  z-index: 100;
+`;
+
+const ModalText = styled.div`
+  margin-bottom: 16px;
+`;
+
+const ModalButtons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  button {
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    cursor: pointer;
+  }
 `;

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -171,12 +171,17 @@ const Subscribers = styled.div`
 const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
   margin-top: 8px;
   padding: 6px 12px;
-  background: ${({ isSubscribed }) => (isSubscribed ? "#869fd4" : "#ffffff")};
+  background: ${({ isSubscribed }) => (isSubscribed ? "#4854a2" : "#ffffff")};
   color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
   border: 1px solid #4854a2;
   border-radius: 8px;
   cursor: pointer;
   justify-content: center;
+
+  &:hover {
+    color: #ffffff;
+    background-color: #6981c8;
+  }
 `;
 
 const StreamTitle = styled.h2`
@@ -193,35 +198,6 @@ const StreamName = styled.h2`
 
 const StreamLine = styled.h2`
   border-top: 1px solid #d9d9d9;
-`;
-
-const StreamCard = styled.div`
-  display: flex;
-  margin: 12px 0;
-`;
-
-const Thumbnail = styled.div`
-  width: 80px;
-  height: 80px;
-  background: #ccc;
-  margin-right: 12px;
-`;
-
-const StreamInfo = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const StreamTitleText = styled.div`
-  font-weight: bold;
-`;
-
-const StreamMeta = styled.div`
-  color: gray;
-`;
-
-const StreamDate = styled.div`
-  color: gray;
 `;
 
 const Modal = styled.div`

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,5 +1,64 @@
+import React, { useState, useEffect, Key } from "react";
 import styled from "styled-components";
 import TopBarLayout from "@/layout/TopBarLayout";
+import InfiniteScroll from "react-infinite-scroll-component";
+import PastStreamCard from "@/pages/mypage/components/host-history/PastStreamCard";
+
+const ProfilePage = () => {
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  interface Stream {
+    channelId: Key | null | undefined;
+    id: string;
+    title: string;
+    thumbnailUrl: string;
+    channelDurationTime: number;
+    channelLastParticipantCount: number;
+    channelCreatedAt: string;
+    channelName: string;
+    // Add other fields as necessary
+  }
+
+  const [streams, setStreams] = useState<Stream[]>([]);
+  const [cursorId, setCursorId] = useState<string | null>(null);
+  const [hasNext, setHasNext] = useState(true);
+
+  useEffect(() => {
+    fetchStreams();
+  }, []);
+
+  const fetchStreams = async () => {
+    if (!hasNext) return;
+    const res = await fetch(`/api/streams?cursorId=${cursorId ?? ""}&size=20`);
+    const data = await res.json();
+    setStreams((prev) => [...prev, ...data.content]);
+    setCursorId(data.lastId);
+    setHasNext(data.hasNext);
+  };
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const { scrollTop, clientHeight, scrollHeight } = e.currentTarget;
+    if (scrollTop + clientHeight >= scrollHeight - 100) {
+      fetchStreams();
+    }
+  };
+
+  const handleSubscribeClick = () => {
+    if (isSubscribed) {
+      setShowConfirmModal(true);
+    } else {
+      setIsSubscribed(true);
+    }
+  };
+
+  const confirmUnsubscribe = () => {
+    setIsSubscribed(false);
+    setShowConfirmModal(false);
+  };
+
+  function fetchNextPage() {
+    throw new Error("Function not implemented.");
+  }
 
   return (
     <Container onScroll={handleScroll}>

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -16,7 +16,6 @@ const ProfilePage = () => {
     channelLastParticipantCount: number;
     channelCreatedAt: string;
     channelName: string;
-    // Add other fields as necessary
   }
 
   const [streams, setStreams] = useState<Stream[]>([]);
@@ -64,7 +63,7 @@ const ProfilePage = () => {
     <Container onScroll={handleScroll}>
       <TopBarLayout
         topBarProps={{
-          title: "송유나님의 프로필", // Replace with actual data source
+          title: "다른사용자님의 프로필", // Replace with actual data source
           backURL: "/mypage",
           hasAction: true,
         }}
@@ -74,7 +73,7 @@ const ProfilePage = () => {
             <LiveBadge>Live</LiveBadge>
           </ProfileImage>
           <UserInfo>
-            <Username>송유나</Username>
+            <Username>다른사용자</Username>
             <Subscribers>구독자 2,586명</Subscribers>
             <SubscribeButton onClick={handleSubscribeClick} isSubscribed={isSubscribed}>
               {isSubscribed ? "구독중" : "구독하기"}
@@ -83,7 +82,7 @@ const ProfilePage = () => {
         </ProfileSection>
         <StreamLine />
         <StreamTitle>
-          <StreamName>송유나</StreamName>님의 과거 스트리밍
+          <StreamName>다른사용자</StreamName>님의 과거 스트리밍
         </StreamTitle>
         <InfiniteScroll
           dataLength={streams.length}

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -171,14 +171,15 @@ const Subscribers = styled.div`
   justify-content: center;
 `;
 
-const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
-  margin-top: 8px;
+const SubscribeButton = styled.button<{ $isSubscribed: boolean }>`
+  margin-right: 20px;
   padding: 6px 12px;
-  background: ${({ isSubscribed }) => (isSubscribed ? "#4854a2" : "#ffffff")};
-  color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
+  background: ${({ $isSubscribed }) => ($isSubscribed ? "#4854a2" : "#ffffff")};
+  color: ${({ $isSubscribed }) => ($isSubscribed ? "#ffffff" : "#4854a2")};
   border: 1px solid #4854a2;
   border-radius: 8px;
   cursor: pointer;
+  display: flex;
   justify-content: center;
 
   &:hover {
@@ -187,19 +188,19 @@ const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
   }
 `;
 
-const StreamTitle = styled.h2`
+const StreamTitle = styled.div`
   font-size: 18px;
   display: flex;
   justify-content: center;
   margin-top: 20px;
 `;
 
-const StreamName = styled.h2`
+const StreamName = styled.span`
   color: #4854a2;
   font-weight: bold;
 `;
 
-const StreamLine = styled.h2`
+const StreamLine = styled.div`
   border-top: 1px solid #d9d9d9;
 `;
 

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,5 +1,194 @@
-import React from "react";
+import styled from "styled-components";
+import TopBarLayout from "@/layout/TopBarLayout";
 
-export default function UserPage() {
-  return <div>UserPage</div>;
-}
+  return (
+    <Container onScroll={handleScroll}>
+      <TopBarLayout
+        topBarProps={{
+          title: "송유나님의 프로필", // Replace with actual data source
+          backURL: "/mypage",
+          hasAction: true,
+        }}
+      >
+        <ProfileSection>
+          <ProfileImage>
+            <LiveBadge>Live</LiveBadge>
+          </ProfileImage>
+          <UserInfo>
+            <Username>송유나</Username>
+            <Subscribers>구독자 2,586명</Subscribers>
+            <SubscribeButton onClick={handleSubscribeClick} isSubscribed={isSubscribed}>
+              {isSubscribed ? "구독중" : "구독하기"}
+            </SubscribeButton>
+          </UserInfo>
+        </ProfileSection>
+        <StreamLine />
+        <StreamTitle>
+          <StreamName>송유나</StreamName>님의 과거 스트리밍
+        </StreamTitle>
+        <InfiniteScroll
+          dataLength={streams.length}
+          next={fetchNextPage}
+          hasMore={hasNext}
+          loader={<p className="p-1 text-center">호스트 이력을 가져오는 중입니다...</p>}
+          endMessage={<p className="py-4 text-center">더 이상의 이력은 없습니다.</p>}
+        >
+          <section className="flex flex-col gap-2 p-4">
+            {streams.map((item) => (
+              <PastStreamCard key={item.channelId} item={item} />
+            ))}
+          </section>
+        </InfiniteScroll>
+
+        {showConfirmModal && (
+          <Modal>
+            <ModalText>구독을 취소하시겠습니까?</ModalText>
+            <ModalButtons>
+              <button onClick={() => setShowConfirmModal(false)}>취소</button>
+              <button onClick={confirmUnsubscribe}>구독 취소</button>
+            </ModalButtons>
+          </Modal>
+        )}
+      </TopBarLayout>
+    </Container>
+  );
+};
+
+export default ProfilePage;
+
+const Container = styled.div`
+  height: 100vh;
+  overflow-y: scroll;
+  padding: 16px;
+  background: white;
+`;
+
+const ProfileSection = styled.div`
+  align-items: center;
+  margin: 28px 0;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const ProfileImage = styled.div`
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: gray;
+`;
+
+const LiveBadge = styled.div`
+  background: red;
+  color: white;
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 8px;
+  width: 35px;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const Username = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+  margin: 8px 0;
+  display: flex;
+  justify-content: center;
+`;
+
+const Subscribers = styled.div`
+  font-size: 14px;
+  color: gray;
+  margin-bottom: 8px;
+  display: flex;
+  justify-content: center;
+`;
+
+const SubscribeButton = styled.button<{ isSubscribed: boolean }>`
+  margin-top: 8px;
+  padding: 6px 12px;
+  background: ${({ isSubscribed }) => (isSubscribed ? "#869fd4" : "#ffffff")};
+  color: ${({ isSubscribed }) => (isSubscribed ? "#ffffff" : "#4854a2")};
+  border: 1px solid #4854a2;
+  border-radius: 8px;
+  cursor: pointer;
+  justify-content: center;
+`;
+
+const StreamTitle = styled.h2`
+  font-size: 18px;
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+`;
+
+const StreamName = styled.h2`
+  color: #4854a2;
+  font-weight: bold;
+`;
+
+const StreamLine = styled.h2`
+  border-top: 1px solid #d9d9d9;
+`;
+
+const StreamCard = styled.div`
+  display: flex;
+  margin: 12px 0;
+`;
+
+const Thumbnail = styled.div`
+  width: 80px;
+  height: 80px;
+  background: #ccc;
+  margin-right: 12px;
+`;
+
+const StreamInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StreamTitleText = styled.div`
+  font-weight: bold;
+`;
+
+const StreamMeta = styled.div`
+  color: gray;
+`;
+
+const StreamDate = styled.div`
+  color: gray;
+`;
+
+const Modal = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 24px;
+  z-index: 100;
+`;
+
+const ModalText = styled.div`
+  margin-bottom: 16px;
+`;
+
+const ModalButtons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  button {
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+`;

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -78,7 +78,7 @@ const UserPage = () => {
           <UserInfo>
             <Username>다른사용자</Username>
             <Subscribers>구독자 2,586명</Subscribers>
-            <SubscribeButton onClick={handleSubscribeClick} isSubscribed={isSubscribed}>
+            <SubscribeButton onClick={handleSubscribeClick} $isSubscribed={isSubscribed}>
               {isSubscribed ? "구독중" : "구독하기"}
             </SubscribeButton>
           </UserInfo>

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -4,7 +4,7 @@ import TopBarLayout from "@/layout/TopBarLayout";
 import InfiniteScroll from "react-infinite-scroll-component";
 import PastStreamCard from "@/pages/mypage/components/host-history/PastStreamCard";
 
-const ProfilePage = () => {
+const UserPage = () => {
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   interface Stream {
@@ -112,7 +112,7 @@ const ProfilePage = () => {
   );
 };
 
-export default ProfilePage;
+export default UserPage;
 
 const Container = styled.div`
   height: 100vh;

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Key } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import TopBarLayout from "@/layout/TopBarLayout";
 import InfiniteScroll from "react-infinite-scroll-component";
@@ -7,15 +7,18 @@ import PastStreamCard from "@/pages/mypage/components/host-history/PastStreamCar
 const UserPage = () => {
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
-  interface Stream {
-    channelId: Key | null | undefined;
+  interface Stream extends IPastStreamContent {
+    channelId: number;
     id: string;
     title: string;
     thumbnailUrl: string;
-    channelDurationTime: number;
+    channelDurationTime: string;
     channelLastParticipantCount: number;
     channelCreatedAt: string;
     channelName: string;
+    channelCategoryName: string;
+    channelThumbnail: string;
+    channelHostName: string;
   }
 
   const [streams, setStreams] = useState<Stream[]>([]);


### PR DESCRIPTION
## 작업
**1. 다른유저페이지**
- UI 구현
- 구독기능, 구독자 수, 과거 스트리밍 카드 구현, alert창 구현
- 프로필 사진 API 나오면 추후 구현 (일단 colorDot로 구현해놓음)
- Live 위치 추후 수정
![버전2  다른 유저 페이지](https://github.com/user-attachments/assets/c5c5b68c-05a5-4b5c-a896-8354cf60e458)
![버전2 구독버튼, alert창 구현](https://github.com/user-attachments/assets/bc23bf01-239d-4a8c-a420-51115b4770d1)


**내가 구독한 구독자**
- UI 구현
- 구독기능, 구독자 수, alert창 구현
- 프로필 사진 API 나오면 추후 구현 (일단 colorDot로 구현해놓음)
![버전2  내가 구독한 구독자 페이지](https://github.com/user-attachments/assets/1b87ab91-b18f-49cf-8127-a35e32889a81)


**검색페이지**
- UI 변경
- 닉네임으로 검색가능
- 구독 & 구독취소 가능
- 프로필 사진 API 나오면 추후 구현 (일단 colorDot로 구현해놓음)
![버전2  검색페이지](https://github.com/user-attachments/assets/1b42d8b5-3895-444c-bfe8-fa455657e01b)


## 참고 사항

<!-- 라이브러리 설치, 작업 관련 주의 사항, 변경 사항 등등 -->

## 관련 이슈

#94 

